### PR TITLE
Fix elevator call response logic

### DIFF
--- a/labs/2 - Heis/skeleton_project/source/modules/states.c
+++ b/labs/2 - Heis/skeleton_project/source/modules/states.c
@@ -65,9 +65,9 @@ void standing_still(state_data *data, int floor) {
 
     // Prefer the direction from the last ride, if available.
     if (data->dir == CURRENT_DIR_UP) {
-        // Look for any orders above the current floor.
+        // Look for any orders above the current floor (both UP and DOWN hall calls)
         for (i = floor + 1; i < N_FLOORS; i++) {
-            if (data->btnStates[i][BUTTON_HALL_UP] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
+            if (data->btnStates[i][BUTTON_HALL_UP] == 1 || data->btnStates[i][BUTTON_HALL_DOWN] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
                 printf("Going up from floor %d to %d\n", floor, i);
                 elevio_motorDirection(DIRN_UP);
                 data->state = DRIVING_UP;
@@ -86,9 +86,9 @@ void standing_still(state_data *data, int floor) {
             }
         }
     } else if (data->dir == CURRENT_DIR_DOWN) {
-        // Look for any orders below the current floor.
+        // Look for any orders below the current floor (both UP and DOWN hall calls)
         for (i = floor - 1; i >= 0; i--) {
-            if (data->btnStates[i][BUTTON_HALL_DOWN] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
+            if (data->btnStates[i][BUTTON_HALL_DOWN] == 1 || data->btnStates[i][BUTTON_HALL_UP] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
                 printf("Going down from floor %d to %d\n", floor, i);
                 elevio_motorDirection(DIRN_DOWN);
                 data->state = DRIVING_DOWN;
@@ -108,7 +108,7 @@ void standing_still(state_data *data, int floor) {
     } else {
         // No previous direction: default to checking up first.
         for (i = floor + 1; i < N_FLOORS; i++) {
-            if (data->btnStates[i][BUTTON_HALL_UP] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
+            if (data->btnStates[i][BUTTON_HALL_UP] == 1 || data->btnStates[i][BUTTON_HALL_DOWN] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
                 printf("Going up from floor %d to %d\n", floor, i);
                 elevio_motorDirection(DIRN_UP);
                 data->state = DRIVING_UP;
@@ -118,7 +118,7 @@ void standing_still(state_data *data, int floor) {
         }
         // Then check downwards.
         for (i = floor - 1; i >= 0; i--) {
-            if (data->btnStates[i][BUTTON_HALL_DOWN] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
+            if (data->btnStates[i][BUTTON_HALL_DOWN] == 1 || data->btnStates[i][BUTTON_HALL_UP] == 1 || data->btnStates[i][BUTTON_CAB] == 1) {
                 printf("Going down from floor %d to %d\n", floor, i);
                 elevio_motorDirection(DIRN_DOWN);
                 data->state = DRIVING_DOWN;


### PR DESCRIPTION
## Summary
- Fixed issue where elevator wouldn't respond to DOWN calls from top floor when at second-to-top floor
- Updated all call handling logic to check for all button types (UP, DOWN, CAB) when deciding elevator movement
- Made direction logic consistent across all conditions

## Test plan
- Test the elevator at floor 2 with a DOWN call from floor 3 - it should now respond
- Test other edge cases to ensure consistent behavior:
  - At floor 0 with UP call from floor 3
  - At floor 3 with DOWN call from floor 0

🤖 Generated with [Claude Code](https://claude.ai/code)